### PR TITLE
Abi3 option to skip trying to use any Python interpreter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,13 @@ fn main() {
 
     let target = Target::current();
     let bridge = BridgeModel::Cffi;
+    println!("Looking for interpreters...");
     let python_interpreters =
         PythonInterpreter::find_all(&target, &bridge).expect("python_interpreter");
+
+    for python_interpreter in &python_interpreters {
+        println!("Found {:?}", python_interpreter);
+    }
 
     // manylinux basically says that there should be a bunch of standard libraries in standard
     // places. This doesn't play nicely with nix so we don't use it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
 
                 let wheel_path = writer.finish().expect("writer finish");
 
-                eprintln!("📦 successfuly created wheel {}", wheel_path.display());
+                eprintln!("📦 successfully created wheel {}", wheel_path.display());
             };
 
             if info.abi3 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,8 @@ fn main() {
                     // places. This doesn't play nicely with nix so we don't use it.
                     py.get_tag(&Manylinux::Off)
                 } else {
-                    let python_tag = "cp3";
+                    // Oldest supported (listed in docs) by pyo3
+                    let python_tag = "cp37";
                     let abi_tag = "abi3";
                     let platform_tag = "linux_x86_64";
                     format!("{}-{}-{}", python_tag, abi_tag, platform_tag)

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,10 @@ fn main() {
                 let python_interpreters =
                     PythonInterpreter::find_all(&target, &bridge).expect("python_interpreter");
 
+                if python_interpreters.is_empty() {
+                    panic!("Couldn't find any recognised Python interpreters")
+                }
+
                 for py in python_interpreters {
                     println!("Found {:?}", py);
                     build_wheel(&Some(py));


### PR DESCRIPTION
Old maturin (0.7.6) doesn't recognise newer Python versions in `PythonInterpreter::find_all` so add a way to bypass it.

This doesn't necessarily need to be merged, especially if upgrading maturin is viable, but might be worth having this branch in your repo so that everything's in one place?